### PR TITLE
Add ioboard scsat1 main

### DIFF
--- a/src/ioboard/ioboard.mk
+++ b/src/ioboard/ioboard.mk
@@ -1,0 +1,1 @@
+IOBOARD_SRCS := scsat1-main.c

--- a/src/ioboard/scsat1-main.c
+++ b/src/ioboard/scsat1-main.c
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2024 Space Cubics, LLC.
+ */
+
+#include "ioboard.h"
+#include "trch.h"
+
+/* Map signal names */
+#define T_UART_DE          UIO3_00
+#define T_UART_RE_B        UIO3_01
+
+void enable_srs3_485(void)
+{
+        T_UART_DE = 1;
+        T_UART_RE_B = 0;
+        __delay_ms(1000);
+}
+
+void disable_srs3_485(void)
+{
+        T_UART_DE = 0;
+        T_UART_RE_B = 1;
+}
+
+int ioboard_init(void)
+{
+        enable_srs3_485();
+
+        return 0;
+}

--- a/src/ioboard/scsat1-main.c
+++ b/src/ioboard/scsat1-main.c
@@ -8,6 +8,7 @@
 /* Map signal names */
 #define T_UART_DE          UIO3_00
 #define T_UART_RE_B        UIO3_01
+#define T_3V3_SYS_EN       UIO3_02
 
 void enable_srs3_485(void)
 {
@@ -24,6 +25,7 @@ void disable_srs3_485(void)
 
 int ioboard_init(void)
 {
+        T_3V3_SYS_EN = 1;
         enable_srs3_485();
 
         return 0;


### PR DESCRIPTION
please review.

the first commit generates a new warning:
```
src/ioboard/scsat1-main.c:20:: warning: (520) function "_disable_srs3_485" is never called
```

Other than that, it looks normal.

```
make clean && make | grep -v -f .warning-filter
rm -rf hex src/*.p1 src/*.a src/*.d MPLABXLog.* log.*
    CC src/main.p1
    CC src/fpga.p1
    CC src/interrupt.p1
    CC src/timer.p1
    CC src/ioboard.p1
    CC src/i2c-gpio.p1
    CC src/ina3221.p1
    CC src/spi.p1
    CC src/tmp175.p1
    CC src/usart.p1
    AR src/libdevice.a
    HEX hex/trch-firmware.hex
src/fpga.c:62:: warning: (520) function "_fpga_is_i2c_accessible" is never called
src/ioboard/scsat1-main.c:20:: warning: (520) function "_disable_srs3_485" is never called
src/fpga.c:28:: warning: (759) expression generates no code
src/fpga.c:43:: warning: (759) expression generates no code

Memory Summary:
    Program space        used   59Fh (  1439) of  2000h words   ( 17.6%)
    Data space           used    65h (   101) of   170h bytes   ( 27.4%)
    EEPROM space         used     0h (     0) of   100h bytes   (  0.0%)
    Configuration bits   used     1h (     1) of     1h word    (100.0%)
    ID Location space    used     0h (     0) of     4h bytes   (  0.0%)
```