### PR TITLE
Add ADCS board as a new target board

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -12,6 +12,9 @@ jobs:
       matrix:
         xc8-version:
           - 'v2.46'
+        target-board:
+          - 'main'
+          - 'adcs'
 
     steps:
       - name: Checkout
@@ -38,4 +41,4 @@ jobs:
       - name: Build
         run: |
           export PATH=$GITHUB_WORKSPACE/$XC8_INSTALL_DIR/bin:$PATH
-          make
+          make TARGET_BOARD=${{ matrix.target-board }}

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@
 CONFIGS := -DCONFIG_ENABLE_WDT_RESET
 #CONFIGS += -DCONFIG_FPGA_PROGRAM_MODE
 CONFIGS += -DCONFIG_FPGA_WATCHDOG_TIMEOUT=30
+TARGET_BOARD ?= main
 
 # Design Parameter
 MODULE := trch-firmware
@@ -24,10 +25,11 @@ PARSER_FLAGS := -Xclang -Wall -Xclang -Wextra -Xclang -Wno-unused-parameter
 
 # Source and object files
 SRCS := src/main.c src/fpga.c src/interrupt.c src/timer.c
+OBJS := $(SRCS:.c=.p1)
 
 -include src/ioboard/ioboard.mk
-SRCS += $(addprefix src/ioboard/,$(IOBOARD_SRCS))
-OBJS := $(SRCS:.c=.p1)
+IOBOARD_SRCS := $(addprefix src/ioboard/,$(IOBOARD_SRCS))
+IOBOARD_OBJS := $(IOBOARD_SRCS:.c=.p1)
 
 LIB_SRCS := src/ioboard.c \
             src/i2c-gpio.c \
@@ -39,7 +41,7 @@ LIB_OBJS := $(LIB_SRCS:.c=.p1)
 
 LIBDEVICE := src/libdevice.a
 
-ALL_OBJS := $(OBJS) $(LIB_OBJS)
+ALL_OBJS := $(OBJS) $(LIB_OBJS) $(IOBOARD_OBJS)
 ALL_DEPS := $(patsubst %.p1,%.d,$(ALL_OBJS))
 
 # Clean File
@@ -59,7 +61,7 @@ all: build
 build: $(PRGDAT).hex
 
 # make sure $(LIBDEVICE) is the last
-$(PRGDAT).hex: $(OBJS) $(LIBDEVICE)
+$(PRGDAT).hex: $(OBJS) src/ioboard/scsat1-$(TARGET_BOARD).p1 $(LIBDEVICE)
 	@mkdir -p $(HEXDIR)
 	@echo '*' > $(HEXDIR)/.gitignore
 	$(QUIET_HEX)$(CC) -o $(HEXDIR)/$(MODULE) $^

--- a/src/ioboard/ioboard.mk
+++ b/src/ioboard/ioboard.mk
@@ -1,1 +1,2 @@
-IOBOARD_SRCS := scsat1-main.c
+IOBOARD_SRCS := scsat1-main.c \
+                scsat1-adcs.c

--- a/src/ioboard/scsat1-adcs.c
+++ b/src/ioboard/scsat1-adcs.c
@@ -1,0 +1,9 @@
+/*
+ * Copyright (c) 2024 Space Cubics, LLC.
+ */
+
+int ioboard_init(void)
+{
+        /* We don't have anything to do for ADCS */
+        return 0;
+}


### PR DESCRIPTION
This commit adds the second target board, ADCS, for SC-Sat1 TRCH. For the ADCS board, all hardware configuration is set to FPGA; thus, we have nothing to do in TRCH.

The build test in GitHub Actions is also updated to specify "TARGET_BOARD."